### PR TITLE
Make it possible to set record range automatically

### DIFF
--- a/settings/nom_settings.yaml
+++ b/settings/nom_settings.yaml
@@ -7,6 +7,8 @@ Start: 2019年5月23日
 End: 2019年7月3日
 Date: 2019年7月4日
 NextDate: 2019年8月11日
+MeetingName: nomlab meeting
+RangeAutoSetFlag: True
 Calendars:
   Labo:
     Ids:

--- a/settings/sw_settings.yaml
+++ b/settings/sw_settings.yaml
@@ -10,6 +10,8 @@ Start: 2019年5月23日
 End: 2019年7月3日
 Date: 2019年7月4日
 NextDate: 2019年8月11日
+MeetingName: 全体ミーティング
+RangeAutoSetFlag: True
 Calendars:
   Labo:
     Ids:


### PR DESCRIPTION
#12 に対するPRである

## やったこと
+ settingsの，AutoRangeSetFlag == Trueなら，自動でStart, End, Date, NextDateを埋める機能を追加した
+ Trueの場合，前後1ヶ月から，settingsのMeetingNameに等しい予定の日付を取得し，それが今日以前ならStart，今日以後ならDateに割り当てる．EndはDate - 1, NextDateは，Dateの一月後である．